### PR TITLE
Fix: Load views and translations in ServiceProvider + Add Spanish localization

### DIFF
--- a/resources/lang/es/checkpoint.php
+++ b/resources/lang/es/checkpoint.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    'title' => 'Punto de control',
+    'group' => 'Configuración',
+    'back' => 'Regresar',
+    'settings' => [
+        'checkpoint' => [
+            'title' => 'Punto de control',
+            'description' => 'Administra la configuración de tu punto de control',
+            'form' => [
+                'seconds' => 'Segundos',
+                'lockouts' => 'Bloqueos',
+                'attempts' => 'Intentos',
+                'max_attempts' => [
+                    'label' => 'Intentos máximos',
+                    'helper_text' => 'El número máximo de intentos fallidos permitidos antes de bloquear al usuario',
+                ],
+                'lockout_duration' => [
+                    'label' => 'Duración del bloqueo',
+                    'helper_text' => 'Duración de tiempo (en segundos) que un usuario permanece bloqueado después de exceder el número máximo de intentos',
+                ],
+                'notify_on_lockout' => [
+                    'label' => 'Notificar al administrador en caso de bloqueo',
+                ],
+            ],
+        ],
+    ],
+];

--- a/src/CheckpointServiceProvider.php
+++ b/src/CheckpointServiceProvider.php
@@ -5,7 +5,6 @@ namespace AskerAkbar\Checkpoint;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Illuminate\Filesystem\Filesystem;
 
 class CheckpointServiceProvider extends PackageServiceProvider
 {
@@ -30,5 +29,11 @@ class CheckpointServiceProvider extends PackageServiceProvider
 
     public function packageBooted(): void
     {
+    }
+
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'checkpoint');
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'checkpoint');
     }
 }


### PR DESCRIPTION
### Summary

This pull request fixes an issue in the package where views and translation files were not being properly loaded, which prevented Laravel from rendering views or resolving localization keys using `__('package::file.key')`.

### Original bugs

This was the original problem
![screenshot](https://github.com/user-attachments/assets/1dd32651-5ba7-40d3-98e5-b1656e5c2324)

Then the "Checkpoint settings view" had this bugs
<img width="1277" alt="Screenshot 2025-04-07 at 13 43 28" src="https://github.com/user-attachments/assets/6784e3d4-c9b5-4e0a-b88d-1c2429ee863c" />


### Changes Made

- Added the `boot()` method to the package’s `ServiceProvider`.
- Registered the following inside `boot()`:
  - `loadViewsFrom(...)` to enable usage of the package’s views.
  - `loadTranslationsFrom(...)` to support namespaced translations.
- Added Spanish (es_MX) translation files, including a complete `checkpoint.php` file.

### Rationale

Without the `boot()` method loading these resources explicitly, Laravel cannot resolve package views or translation keys, breaking key features when integrating this package into a Laravel application. This update ensures the package complies with Laravel's best practices for package development and integration.



### Notes

- Tested on Laravel 10 and 11.
- After upgrading the package, it is recommended to run `php artisan config:clear` and `php artisan cache:clear` to avoid cache-related issues.
